### PR TITLE
ensure the `time` property comes first when serialized

### DIFF
--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -59,6 +59,36 @@ func TestStringWithJSON(t *testing.T) {
 	}
 }
 
+func TestStringWithJSONTimePropertyComesFirstAndIsEncoded(t *testing.T) {
+	d := time.Date(2016, 6, 13, 12, 23, 42, 123456000, time.Local)
+	json := make(map[string]interface{})
+	json["msg"] = "hello world"
+	json["time"] = `funky "time"`
+	m := Message{
+		Group:  "abc",
+		Stream: "0123456789",
+		Event: ecslogs.Event{
+			Level:   ecslogs.INFO,
+			Time:    d,
+			Message: "Hello World!",
+			Info:    ecslogs.EventInfo{Host: "localhost"},
+			Data:    ecslogs.EventData{},
+		},
+		JSON: json,
+	}
+
+	ref := `{"time":"funky \"time\"","msg":"hello world"}`
+
+	if s := m.String(); s != ref {
+		t.Errorf("invalid string representation of the message:\n - expected: %s\n - found:    %s", ref, s)
+	}
+
+	// twice to assert we didn't mutate JSON
+	if s := m.String(); s != ref {
+		t.Errorf("appears we mutated the JSON:\n - expected: %s\n - found:    %s", ref, s)
+	}
+}
+
 func TestMessageEncoderDecoder(t *testing.T) {
 	batch := MessageBatch{
 		Message{


### PR DESCRIPTION
Sumo Logic will use the first timestamp-looking-string it finds in the log line as the timestamp.  This change ensures our `time` property appears first in the outgoing JSON.

@swettk btw: `_time` sorts after numbers and uppercase letters it turns out, so I went with my original plan.