### PR TITLE
update our docker image to goodeggs/platform-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # We need a go compiler that's based on an image with libsystemd-dev installed,
 # segment/golang give us just that.
-FROM segment/golang:latest
+FROM goodeggs/platform-base:2.1.0 as base
+
+FROM base as build
+
+ENV GOPATH=/go
+
+RUN install_packages build-essential golang govendor libsystemd-dev
 
 # Copy the ecs-logs sources so they can be built within the container.
 COPY . /go/src/github.com/segmentio/ecs-logs
@@ -8,11 +14,11 @@ COPY . /go/src/github.com/segmentio/ecs-logs
 # Build ecs-logs, then cleanup all unneeded packages.
 RUN cd /go/src/github.com/segmentio/ecs-logs && \
     govendor sync && \
-    go build -o /usr/local/bin/ecs-logs && \
-    apt-get remove -y apt-transport-https build-essential git curl docker-engine && \
-    apt-get autoremove -y && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* /go/* /usr/local/go /usr/src/Makefile*
+    go build -o /usr/local/bin/ecs-logs
+
+FROM base
+
+COPY --from=build /usr/local/bin/ecs-logs /usr/local/bin/
 
 # Sets the container's entry point.
 ENTRYPOINT ["ecs-logs"]


### PR DESCRIPTION
the old image's libsystemd was incompatible with the host system's
systemd version.  we'll do one better than just fixing it and actually
make the docker image use our platform-base image, which we intend to
keep matching with the AMI base image!